### PR TITLE
CASE 1: Extend mappers and UI codebase to show the apartment name.

### DIFF
--- a/src/models/Door.ts
+++ b/src/models/Door.ts
@@ -5,6 +5,7 @@ export interface Door {
   id: string;
   name: string;
   buildingName: string;
+  apartmentName: string;
   connectionType: ConnectionType;
   connectionStatus: ConnectionStatus;
   lastConnectionStatusUpdate: string;

--- a/src/server/mappers/DoorMapper.test.ts
+++ b/src/server/mappers/DoorMapper.test.ts
@@ -20,6 +20,13 @@ const doorDto: DoorDto = {
   building_id: buildingDto.id,
 };
 
+const apartmentDto = {
+  id: '63f4e2825abc011556da74af',
+  name: 'Apartment 1.1',
+  floor: 1,
+  building_id: buildingDto.id,
+};
+
 describe('DoorMapper', () => {
   let doorMapper: DoorMapper;
 
@@ -28,13 +35,18 @@ describe('DoorMapper', () => {
   });
 
   it('should map dto to Door model', () => {
-    const door = doorMapper.toDomain(doorDto, {
-      [buildingDto.id]: buildingDto,
-    });
+    const door = doorMapper.toDomain(
+      doorDto,
+      {
+        [buildingDto.id]: buildingDto,
+      },
+      {},
+    );
 
     expect(door).toMatchObject<Door>({
       id: doorDto.id,
       name: doorDto.name,
+      apartmentName: door.apartmentName,
       buildingName: `${buildingDto.street} ${buildingDto.street_no}`,
       connectionType: doorDto.connection_type,
       connectionStatus: doorDto.connection_status,
@@ -43,12 +55,37 @@ describe('DoorMapper', () => {
   });
 
   it('should set building name to "n/a" if no matching building is found', () => {
-    const door = doorMapper.toDomain(doorDto, {});
+    const door = doorMapper.toDomain(
+      doorDto,
+      {},
+      { [apartmentDto.id]: apartmentDto },
+    );
 
     expect(door).toMatchObject<Door>({
       id: doorDto.id,
       name: doorDto.name,
+      apartmentName: door.apartmentName,
       buildingName: 'n/a',
+      connectionType: doorDto.connection_type,
+      connectionStatus: doorDto.connection_status,
+      lastConnectionStatusUpdate: doorDto.last_connection_status_update,
+    });
+  });
+
+  it('should set apartment name to "n/a" if no matching apartments is found', () => {
+    const door = doorMapper.toDomain(
+      doorDto,
+      {
+        [buildingDto.id]: buildingDto,
+      },
+      {},
+    );
+
+    expect(door).toMatchObject<Door>({
+      id: doorDto.id,
+      name: doorDto.name,
+      apartmentName: 'n/a',
+      buildingName: `${buildingDto.street} ${buildingDto.street_no}`,
       connectionType: doorDto.connection_type,
       connectionStatus: doorDto.connection_status,
       lastConnectionStatusUpdate: doorDto.last_connection_status_update,

--- a/src/server/mappers/DoorMapper.test.ts
+++ b/src/server/mappers/DoorMapper.test.ts
@@ -2,6 +2,7 @@ import { BuildingDto } from '@/__mocks__/dtos/BuidlingDto';
 import { DoorDto } from '@/__mocks__/dtos/DoorDto';
 import { Door } from '@/models/Door';
 import { DoorMapper } from './DoorMapper';
+import { ApartmentDto } from '@/__mocks__/dtos/ApartmentDto';
 
 const buildingDto: BuildingDto = {
   id: '63f4e0797e85310fee059022',
@@ -18,9 +19,10 @@ const doorDto: DoorDto = {
   connection_status: 'online',
   last_connection_status_update: '2023-02-22T02:38:40.374Z',
   building_id: buildingDto.id,
+  apartment_id: '63f4e2825abc011556da74af',
 };
 
-const apartmentDto = {
+const apartmentDto: ApartmentDto = {
   id: '63f4e2825abc011556da74af',
   name: 'Apartment 1.1',
   floor: 1,
@@ -40,7 +42,7 @@ describe('DoorMapper', () => {
       {
         [buildingDto.id]: buildingDto,
       },
-      {},
+      { [apartmentDto.id]: apartmentDto },
     );
 
     expect(door).toMatchObject<Door>({

--- a/src/server/mappers/DoorMapper.ts
+++ b/src/server/mappers/DoorMapper.ts
@@ -10,6 +10,8 @@ export type ApartmentDtoById = Record<string, ApartmentDto>;
 
 @injectable()
 export class DoorMapper implements EntityMapper<Door, DoorDto> {
+  private static readonly NON_APPLICABLE = 'n/a';
+
   public toDomain(
     doorDto: DoorDto,
     buildingDtosById: BuildingDtosById,
@@ -20,7 +22,7 @@ export class DoorMapper implements EntityMapper<Door, DoorDto> {
       doorDto.building_id,
     );
 
-    const apartmentName = this.getApartmentsName(
+    const apartmentName = this.getApartmentName(
       apartmentsDtoById,
       doorDto.apartment_id,
     );
@@ -36,19 +38,21 @@ export class DoorMapper implements EntityMapper<Door, DoorDto> {
     };
   }
 
-  private getApartmentsName(apartmentsDto: ApartmentDtoById, id?: string) {
+  private getApartmentName(apartmentsDto: ApartmentDtoById, id?: string) {
     if (!id) {
-      return 'n/a';
+      return DoorMapper.NON_APPLICABLE;
     }
 
     const apartment = apartmentsDto[id];
 
-    return apartment ? apartment.name : 'n/a';
+    return apartment ? apartment.name : DoorMapper.NON_APPLICABLE;
   }
 
   private getBuildingName(buildingDtos: BuildingDtosById, id: string) {
     const building = buildingDtos[id];
 
-    return building ? `${building.street} ${building.street_no}` : 'n/a';
+    return building
+      ? `${building.street} ${building.street_no}`
+      : DoorMapper.NON_APPLICABLE;
   }
 }

--- a/src/server/mappers/DoorMapper.ts
+++ b/src/server/mappers/DoorMapper.ts
@@ -3,25 +3,41 @@ import { injectable } from 'tsyringe';
 import { EntityMapper } from '@/server/lib/EntityMapper';
 import { DoorDto } from '@/__mocks__/dtos/DoorDto';
 import { BuildingDto } from '@/__mocks__/dtos/BuidlingDto';
+import { ApartmentDto } from '@/__mocks__/dtos/ApartmentDto';
 
 type BuildingDtosById = Record<string, BuildingDto>;
+export type ApartmentDtoById = Record<string, ApartmentDto>;
 
 @injectable()
 export class DoorMapper implements EntityMapper<Door, DoorDto> {
-  public toDomain(doorDto: DoorDto, buildingDtosById: BuildingDtosById): Door {
+  public toDomain(
+    doorDto: DoorDto,
+    buildingDtosById: BuildingDtosById,
+    apartmentsDtoById: ApartmentDtoById,
+  ): Door {
     const buildingName = this.getBuildingName(
       buildingDtosById,
       doorDto.building_id,
+    );
+
+    const apartmentName = this.getApartmentsName(
+      apartmentsDtoById,
+      doorDto.apartment_id,
     );
 
     return {
       id: doorDto.id,
       name: doorDto.name,
       buildingName,
+      apartmentName,
       connectionType: doorDto.connection_type,
       connectionStatus: doorDto.connection_status,
       lastConnectionStatusUpdate: doorDto.last_connection_status_update,
     };
+  }
+
+  private getApartmentsName(apartmentsDto: ApartmentDtoById, id?: string) {
+    return id ? apartmentsDto[id].name : 'n/a';
   }
 
   private getBuildingName(buildingDtos: BuildingDtosById, id: string) {

--- a/src/server/mappers/DoorMapper.ts
+++ b/src/server/mappers/DoorMapper.ts
@@ -37,7 +37,13 @@ export class DoorMapper implements EntityMapper<Door, DoorDto> {
   }
 
   private getApartmentsName(apartmentsDto: ApartmentDtoById, id?: string) {
-    return id ? apartmentsDto[id].name : 'n/a';
+    if (!id) {
+      return 'n/a';
+    }
+
+    const apartment = apartmentsDto[id];
+
+    return apartment ? apartment.name : 'n/a';
   }
 
   private getBuildingName(buildingDtos: BuildingDtosById, id: string) {

--- a/src/server/useCases/GetDoorListUseCase.ts
+++ b/src/server/useCases/GetDoorListUseCase.ts
@@ -6,26 +6,30 @@ import { UseCase } from '@/server/lib/UseCase';
 import { DoorRepository } from '@/server/repositories/DoorRepository';
 import { BuildingRepository } from '@/server/repositories/BuildingRepository';
 import { DoorMapper } from '@/server/mappers/DoorMapper';
+import { ApartmentRepository } from '../repositories/ApartmentRepository';
 
 @injectable()
 export class GetDoorListUseCase implements UseCase<Door[]> {
   constructor(
     private doorRepository: DoorRepository,
     private buildingRepository: BuildingRepository,
+    private apartmentsRepository: ApartmentRepository,
     private doorMapper: DoorMapper,
   ) {}
 
   public async execute() {
     try {
-      const [doorDtos, buildingDtos] = await Promise.all([
+      const [doorDtos, buildingDtos, apartmentsDtos] = await Promise.all([
         this.doorRepository.getAllDoors(),
         this.buildingRepository.getAllBuildings(),
+        this.apartmentsRepository.getAllApartments(),
       ]);
 
       const buildingDtosById = keyBy(buildingDtos, 'id');
+      const apartmentsDtosById = keyBy(apartmentsDtos, 'id');
 
       return doorDtos.map((doorDto) =>
-        this.doorMapper.toDomain(doorDto, buildingDtosById),
+        this.doorMapper.toDomain(doorDto, buildingDtosById, apartmentsDtosById),
       );
     } catch (error) {
       throw new createHttpError.ServiceUnavailable();

--- a/src/ui/components/DoorDetail.test.tsx
+++ b/src/ui/components/DoorDetail.test.tsx
@@ -6,6 +6,7 @@ const door: Door = {
   id: '63f637c9f3c48a124616044b',
   name: 'Building Main Entrance',
   buildingName: 'Bahnhofstrasse 10A',
+  apartmentName: 'Apartment 1.1',
   connectionType: 'wired',
   connectionStatus: 'offline',
   lastConnectionStatusUpdate: '2023-02-22T03:00:11.853Z',

--- a/src/ui/components/DoorDetail.tsx
+++ b/src/ui/components/DoorDetail.tsx
@@ -16,6 +16,9 @@ export function DoorDetail({ door }: DoorDetailProps) {
       <DetailPageItem label="Building">
         <Typography>{door.buildingName}</Typography>
       </DetailPageItem>
+      <DetailPageItem label="Apartment">
+        <Typography>{door.apartmentName}</Typography>
+      </DetailPageItem>
       <DetailPageItem label="Connection type">
         <Typography>{door.connectionType}</Typography>
       </DetailPageItem>

--- a/src/ui/components/DoorList.test.tsx
+++ b/src/ui/components/DoorList.test.tsx
@@ -9,6 +9,7 @@ const doors: Door[] = [
     id: '63f637c9f3c48a124616044b',
     name: 'Building Main Entrance',
     buildingName: 'Bahnhofstrasse 10A',
+    apartmentName: 'Apartment 1.1',
     connectionType: 'wired',
     connectionStatus: 'offline',
     lastConnectionStatusUpdate: '2023-02-22T03:00:11.853Z',

--- a/src/ui/components/DoorList.tsx
+++ b/src/ui/components/DoorList.tsx
@@ -20,6 +20,11 @@ const columns: GridColDef<Door>[] = [
     flex: 1,
   },
   {
+    field: 'apartmentName',
+    headerName: 'Apartment',
+    flex: 1,
+  },
+  {
     field: 'connectionType',
     headerName: 'Connection type',
     flex: 1,

--- a/src/ui/components/__snapshots__/DoorDetail.test.tsx.snap
+++ b/src/ui/components/__snapshots__/DoorDetail.test.tsx.snap
@@ -43,6 +43,22 @@ exports[`DoorDetail should render correctly 1`] = `
       class="MuiTypography-root MuiTypography-body1 css-rizt0-MuiTypography-root"
     >
       <strong>
+        Apartment
+      </strong>
+    </p>
+    <p
+      class="MuiTypography-root MuiTypography-body1 css-rizt0-MuiTypography-root"
+    >
+      Apartment 1.1
+    </p>
+  </div>
+  <div
+    class="MuiBox-root css-0"
+  >
+    <p
+      class="MuiTypography-root MuiTypography-body1 css-rizt0-MuiTypography-root"
+    >
+      <strong>
         Connection type
       </strong>
     </p>

--- a/src/ui/components/__snapshots__/DoorList.test.tsx.snap
+++ b/src/ui/components/__snapshots__/DoorList.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`DoorList should render correctly 1`] = `
   style="--DataGrid-width: 0px; --DataGrid-hasScrollX: 0; --DataGrid-hasScrollY: 1; --DataGrid-scrollbarSize: 0px; --DataGrid-rowWidth: 0px; --DataGrid-columnsTotalWidth: 0px; --DataGrid-leftPinnedWidth: 0px; --DataGrid-rightPinnedWidth: 0px; --DataGrid-headerHeight: 56px; --DataGrid-headersTotalHeight: 56px; --DataGrid-topContainerHeight: 56px; --DataGrid-bottomContainerHeight: 0px; --height: 52px;"
 >
   <div
-    aria-colcount="4"
+    aria-colcount="5"
     aria-multiselectable="false"
     aria-rowcount="2"
     class="MuiDataGrid-main css-1bgckiu-MuiDataGrid-main"
@@ -244,7 +244,7 @@ exports[`DoorList should render correctly 1`] = `
               aria-colindex="3"
               aria-sort="none"
               class="MuiDataGrid-columnHeader MuiDataGrid-columnHeader--sortable MuiDataGrid-withBorderColor"
-              data-field="connectionType"
+              data-field="apartmentName"
               role="columnheader"
               style="height: 56px; width: 0px;"
               tabindex="-1"
@@ -265,7 +265,7 @@ exports[`DoorList should render correctly 1`] = `
                       class="MuiDataGrid-columnHeaderTitle css-1gqmilo-MuiDataGrid-columnHeaderTitle"
                       data-mui-internal-clone-element="true"
                     >
-                      Connection type
+                      Apartment
                     </div>
                   </div>
                   <div
@@ -274,7 +274,7 @@ exports[`DoorList should render correctly 1`] = `
                     <button
                       aria-label="Sort"
                       class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-r363y4-MuiButtonBase-root-MuiIconButton-root"
-                      field="connectionType"
+                      field="apartmentName"
                       tabindex="-1"
                       title="Sort"
                       type="button"
@@ -343,6 +343,106 @@ exports[`DoorList should render correctly 1`] = `
             <div
               aria-colindex="4"
               aria-sort="none"
+              class="MuiDataGrid-columnHeader MuiDataGrid-columnHeader--sortable MuiDataGrid-withBorderColor"
+              data-field="connectionType"
+              role="columnheader"
+              style="height: 56px; width: 0px;"
+              tabindex="-1"
+            >
+              <div
+                class="MuiDataGrid-columnHeaderDraggableContainer"
+                draggable="false"
+                role="presentation"
+              >
+                <div
+                  class="MuiDataGrid-columnHeaderTitleContainer"
+                  role="presentation"
+                >
+                  <div
+                    class="MuiDataGrid-columnHeaderTitleContainerContent"
+                  >
+                    <div
+                      class="MuiDataGrid-columnHeaderTitle css-1gqmilo-MuiDataGrid-columnHeaderTitle"
+                      data-mui-internal-clone-element="true"
+                    >
+                      Connection type
+                    </div>
+                  </div>
+                  <div
+                    class="MuiDataGrid-iconButtonContainer css-ltf0zy-MuiDataGrid-iconButtonContainer"
+                  >
+                    <button
+                      aria-label="Sort"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall css-r363y4-MuiButtonBase-root-MuiIconButton-root"
+                      field="connectionType"
+                      tabindex="-1"
+                      title="Sort"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall MuiDataGrid-sortIcon css-120dh41-MuiSvgIcon-root"
+                        data-testid="ArrowUpwardIcon"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M4 12l1.41 1.41L11 7.83V20h2V7.83l5.58 5.59L20 12l-8-8-8 8z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+                <div
+                  class="MuiDataGrid-menuIcon"
+                >
+                  <button
+                    aria-expanded="false"
+                    aria-haspopup="menu"
+                    aria-label="Menu"
+                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall MuiDataGrid-menuIconButton css-r363y4-MuiButtonBase-root-MuiIconButton-root"
+                    data-mui-internal-clone-element="true"
+                    id=":rj:"
+                    tabindex="-1"
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root MuiSvgIcon-fontSizeInherit css-1ckov0h-MuiSvgIcon-root"
+                      data-testid="TripleDotsVerticalIcon"
+                      focusable="false"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        d="M12 8c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z"
+                      />
+                    </svg>
+                  </button>
+                </div>
+              </div>
+              <div
+                class="MuiDataGrid-columnSeparator MuiDataGrid-columnSeparator--resizable MuiDataGrid-columnSeparator--sideRight"
+                style="min-height: 56px;"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium MuiDataGrid-iconSeparator css-1umw9bq-MuiSvgIcon-root"
+                  data-testid="SeparatorIcon"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <rect
+                    height="24"
+                    rx="0.5"
+                    width="1"
+                    x="11.5"
+                  />
+                </svg>
+              </div>
+            </div>
+            <div
+              aria-colindex="5"
+              aria-sort="none"
               class="MuiDataGrid-columnHeader MuiDataGrid-columnHeader--sortable MuiDataGrid-withBorderColor MuiDataGrid-columnHeader--lastUnpinned MuiDataGrid-columnHeader--last"
               data-field="connectionStatus"
               role="columnheader"
@@ -402,7 +502,7 @@ exports[`DoorList should render correctly 1`] = `
                     aria-label="Menu"
                     class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall MuiDataGrid-menuIconButton css-r363y4-MuiButtonBase-root-MuiIconButton-root"
                     data-mui-internal-clone-element="true"
-                    id=":rj:"
+                    id=":rp:"
                     tabindex="-1"
                     type="button"
                   >
@@ -509,6 +609,20 @@ exports[`DoorList should render correctly 1`] = `
               aria-rowspan="1"
               class="MuiDataGrid-cell MuiDataGrid-cell--textLeft"
               data-colindex="2"
+              data-field="apartmentName"
+              role="gridcell"
+              style="--width: 0px;"
+              tabindex="-1"
+              title="Apartment 1.1"
+            >
+              Apartment 1.1
+            </div>
+            <div
+              aria-colindex="4"
+              aria-colspan="1"
+              aria-rowspan="1"
+              class="MuiDataGrid-cell MuiDataGrid-cell--textLeft"
+              data-colindex="3"
               data-field="connectionType"
               role="gridcell"
               style="--width: 0px;"
@@ -518,11 +632,11 @@ exports[`DoorList should render correctly 1`] = `
               wired
             </div>
             <div
-              aria-colindex="4"
+              aria-colindex="5"
               aria-colspan="1"
               aria-rowspan="1"
               class="MuiDataGrid-cell MuiDataGrid-cell--textLeft"
-              data-colindex="3"
+              data-colindex="4"
               data-field="connectionStatus"
               role="gridcell"
               style="--width: 0px;"


### PR DESCRIPTION
Use Case 1: 
As a user I can see the apartment name.

Task description:
Some of the doors belong to an apartment. You must provide this information to the real estate manager (application user). Extend the door list and door detail page with the apartments name.

Changes made: 
* adds apartment name to doors list

* adds apartment name to door detail page

* updated dtos and mappers to correctly fetch the needed data about the apartment name

* fix and extends tests to cover the new logic

<img width="1673" alt="Screenshot 2024-12-11 at 16 29 26" src="https://github.com/user-attachments/assets/47d7b0f9-a658-4abf-bf5b-ad9737960caa" />
<img width="1680" alt="Screenshot 2024-12-11 at 16 29 37" src="https://github.com/user-attachments/assets/e69d4d07-2393-4d9a-bb9c-7a84e2a0bf8a" />