### PR TITLE
CASE 2: Remove hardcoded connection status and create new component for showing the actual connection status.

### DIFF
--- a/src/ui/components/ConnectionStatusCell.test.tsx
+++ b/src/ui/components/ConnectionStatusCell.test.tsx
@@ -1,0 +1,14 @@
+import { render } from '@testing-library/react';
+import { ConnectionStatusCell } from './ConnectionStatusCell';
+import { ConnectionStatus } from '@/models/ConnectionStatus';
+
+const connectionStatus: ConnectionStatus = ConnectionStatus.Online;
+
+describe('ConnectionStatusCell', () => {
+  it('should render correctly', () => {
+    const { container } = render(
+      <ConnectionStatusCell connectionStatus={connectionStatus} />,
+    );
+    expect(container.firstChild).toMatchSnapshot();
+  });
+});

--- a/src/ui/components/ConnectionStatusCell.test.tsx
+++ b/src/ui/components/ConnectionStatusCell.test.tsx
@@ -2,12 +2,10 @@ import { render } from '@testing-library/react';
 import { ConnectionStatusCell } from './ConnectionStatusCell';
 import { ConnectionStatus } from '@/models/ConnectionStatus';
 
-const connectionStatus: ConnectionStatus = ConnectionStatus.Online;
-
 describe('ConnectionStatusCell', () => {
   it('should render correctly', () => {
     const { container } = render(
-      <ConnectionStatusCell connectionStatus={connectionStatus} />,
+      <ConnectionStatusCell connectionStatus={ConnectionStatus.Online} />,
     );
     expect(container.firstChild).toMatchSnapshot();
   });

--- a/src/ui/components/ConnectionStatusCell.tsx
+++ b/src/ui/components/ConnectionStatusCell.tsx
@@ -1,0 +1,21 @@
+import { ConnectionStatus } from '@/models/ConnectionStatus';
+import { Typography } from '@mui/material';
+
+interface ConnectionStatusCellProps {
+  connectionStatus: ConnectionStatus;
+}
+
+export function ConnectionStatusCell({
+  connectionStatus,
+}: ConnectionStatusCellProps) {
+  const isOnline = connectionStatus === ConnectionStatus.Online;
+
+  return (
+    <Typography
+      component="span"
+      color={isOnline ? 'success.main' : 'error.main'}
+    >
+      {connectionStatus}
+    </Typography>
+  );
+}

--- a/src/ui/components/DoorDetail.tsx
+++ b/src/ui/components/DoorDetail.tsx
@@ -2,6 +2,7 @@ import Typography from '@mui/material/Typography';
 import { Door } from '@/models/Door';
 import { DetailPageContainer } from '@/ui/layout/DetailPageContainer';
 import { DetailPageItem } from '@/ui/layout/DetailPageItem';
+import { ConnectionStatusCell } from './ConnectionStatusCell';
 
 interface DoorDetailProps {
   door: Door;
@@ -23,7 +24,7 @@ export function DoorDetail({ door }: DoorDetailProps) {
         <Typography>{door.connectionType}</Typography>
       </DetailPageItem>
       <DetailPageItem label="Connection status">
-        <Typography color="success.main">online</Typography>
+        <ConnectionStatusCell connectionStatus={door.connectionStatus} />
       </DetailPageItem>
     </DetailPageContainer>
   );

--- a/src/ui/components/DoorList.tsx
+++ b/src/ui/components/DoorList.tsx
@@ -2,7 +2,7 @@ import { useRouter } from 'next/router';
 import { useCallback } from 'react';
 import { Door } from '@/models/Door';
 import { DataGrid, GridColDef, GridRowParams } from '@mui/x-data-grid';
-import Typography from '@mui/material/Typography';
+import { ConnectionStatusCell } from './ConnectionStatusCell';
 
 interface DoorListProps {
   doors: Door[];
@@ -33,13 +33,8 @@ const columns: GridColDef<Door>[] = [
     field: 'connectionStatus',
     headerName: 'Connection status',
     flex: 1,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     renderCell: ({ row: door }) => {
-      return (
-        <Typography component="span" color="success.main">
-          online
-        </Typography>
-      );
+      return <ConnectionStatusCell connectionStatus={door.connectionStatus} />;
     },
   },
 ];

--- a/src/ui/components/__snapshots__/ConnectionStatusCell.test.tsx.snap
+++ b/src/ui/components/__snapshots__/ConnectionStatusCell.test.tsx.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ConnectionStatusCell should render correctly 1`] = `
+<span
+  class="MuiTypography-root MuiTypography-body1 css-wl91uy-MuiTypography-root"
+>
+  online
+</span>
+`;

--- a/src/ui/components/__snapshots__/DoorDetail.test.tsx.snap
+++ b/src/ui/components/__snapshots__/DoorDetail.test.tsx.snap
@@ -78,11 +78,11 @@ exports[`DoorDetail should render correctly 1`] = `
         Connection status
       </strong>
     </p>
-    <p
-      class="MuiTypography-root MuiTypography-body1 css-wl91uy-MuiTypography-root"
+    <span
+      class="MuiTypography-root MuiTypography-body1 css-4sq7ol-MuiTypography-root"
     >
-      online
-    </p>
+      offline
+    </span>
   </div>
 </div>
 `;

--- a/src/ui/components/__snapshots__/DoorList.test.tsx.snap
+++ b/src/ui/components/__snapshots__/DoorList.test.tsx.snap
@@ -643,9 +643,9 @@ exports[`DoorList should render correctly 1`] = `
               tabindex="-1"
             >
               <span
-                class="MuiTypography-root MuiTypography-body1 css-wl91uy-MuiTypography-root"
+                class="MuiTypography-root MuiTypography-body1 css-4sq7ol-MuiTypography-root"
               >
-                online
+                offline
               </span>
             </div>
           </div>


### PR DESCRIPTION
Use Case 2: 
As a user I can see the correct connection status.

Task description: 
Fix the bug where "connection status" is always "online" despite some of the doors being "offline". The real estate manager (application user) must have the correct information to check which doors are connected to the IoT server and which ones potentially have connection issues.

Changes made: 
 * Create new component for showing the correct connection status 
 * Remove hardcoded 'online' value from DoorList and DoorDetail and replace it with the newly created component 
 * Update snapshots to pass all the tests
 
 
<img width="1537" alt="Screenshot 2024-12-11 at 17 33 04" src="https://github.com/user-attachments/assets/ca17c8b0-4286-4af1-aa81-fe994b70e2ff" />
<img width="1680" alt="Screenshot 2024-12-11 at 17 33 13" src="https://github.com/user-attachments/assets/f2f5b01a-437f-491c-9e9f-3b030b96440d" />
<img width="1680" alt="Screenshot 2024-12-11 at 17 33 25" src="https://github.com/user-attachments/assets/5ce41fc6-2ece-4520-b52f-da5c94dca003" />

 