### PR TITLE
Add additional tests in server files

### DIFF
--- a/src/server/mappers/DoorMapper.test.ts
+++ b/src/server/mappers/DoorMapper.test.ts
@@ -93,4 +93,18 @@ describe('DoorMapper', () => {
       lastConnectionStatusUpdate: doorDto.last_connection_status_update,
     });
   });
+
+  it('should set apartment name and building name to "n/a" if no matching apartments and buildings are found', () => {
+    const door = doorMapper.toDomain(doorDto, {}, {});
+
+    expect(door).toMatchObject<Door>({
+      id: doorDto.id,
+      name: doorDto.name,
+      apartmentName: 'n/a',
+      buildingName: 'n/a',
+      connectionType: doorDto.connection_type,
+      connectionStatus: doorDto.connection_status,
+      lastConnectionStatusUpdate: doorDto.last_connection_status_update,
+    });
+  });
 });

--- a/src/server/useCases/GetDoorByIdUseCase.test.ts
+++ b/src/server/useCases/GetDoorByIdUseCase.test.ts
@@ -5,6 +5,8 @@ import { DoorDto } from '@/__mocks__/dtos/DoorDto';
 import { DoorRepository } from '@/server/repositories/DoorRepository';
 import { BuildingRepository } from '@/server/repositories/BuildingRepository';
 import { GetDoorByIdUseCase } from './GetDoorByIdUseCase';
+import { ApartmentDto } from '@/__mocks__/dtos/ApartmentDto';
+import { ApartmentRepository } from '../repositories/ApartmentRepository';
 
 const buildingDto: BuildingDto = {
   id: '63f4e0797e85310fee059022',
@@ -20,6 +22,14 @@ const doorDto: DoorDto = {
   connection_type: 'wired',
   connection_status: 'online',
   last_connection_status_update: '2023-02-22T22:01:47.573Z',
+  building_id: buildingDto.id,
+  apartment_id: '63f4e2825abc011556da74af',
+};
+
+const apartmentDto: ApartmentDto = {
+  id: '63f4e2825abc011556da74af',
+  name: 'Apartment 1.1',
+  floor: 1,
   building_id: buildingDto.id,
 };
 
@@ -40,10 +50,15 @@ describe('GetDoorByIdUseCase', () => {
       .spyOn(BuildingRepository.prototype, 'getBuildingById')
       .mockImplementation(() => Promise.resolve(buildingDto));
 
+    const getApartmentByIdSpy = jest
+      .spyOn(ApartmentRepository.prototype, 'getApartmentById')
+      .mockImplementation(() => Promise.resolve(apartmentDto));
+
     await getDoorByIdUseCase.execute({ doorId: doorDto.id });
 
     expect(getDoorByIdSpy).toHaveBeenNthCalledWith(1, doorDto.id);
     expect(getBuildingByIdSpy).toHaveBeenNthCalledWith(1, buildingDto.id);
+    expect(getApartmentByIdSpy).toHaveBeenNthCalledWith(1, apartmentDto.id);
   });
 
   it('should throw if no door could be found', async () => {

--- a/src/server/useCases/GetDoorListUseCase.test.ts
+++ b/src/server/useCases/GetDoorListUseCase.test.ts
@@ -21,10 +21,15 @@ describe('GetDoorListUseCase', () => {
       .spyOn(BuildingRepository.prototype, 'getAllBuildings')
       .mockImplementation(() => Promise.resolve([]));
 
+    const getAllApartmentsSpy = jest
+      .spyOn(BuildingRepository.prototype, 'getAllBuildings')
+      .mockImplementation(() => Promise.resolve([]));
+
     await getDoorListUseCase.execute();
 
     expect(getAllDoorsSpy).toHaveBeenCalledTimes(1);
     expect(getAllBuildingsSpy).toHaveBeenCalledTimes(1);
+    expect(getAllApartmentsSpy).toHaveBeenCalledTimes(1);
   });
 
   it('should throw if getAllBuildings request fails', async () => {


### PR DESCRIPTION
Changes made: 
* Add additional test in server/mappers/DoorMapper.test.ts to check if both apartment name and building name are missing the correct response will be returned 
* Add additional test in server/useCases/GetDoorByIdUseCase.test.ts to ensure that also apartments repository method will be called 
* Add additional test in server/useCases/GetDoorListUseCase.test.ts to ensure that also apartments repository method will be called 